### PR TITLE
hotfix created_at

### DIFF
--- a/src/Listener/BlamableListener.php
+++ b/src/Listener/BlamableListener.php
@@ -56,7 +56,7 @@ class BlamableListener
         $entity->setUpdatedBy($updated_by);
         $entity->setUpdatedAt($changed_at);
 
-        if ($event->getEntityManager()->getUnitOfWork()->isScheduledForInsert($entity)) {
+        if (null === $event->getOriginalEntity()) {
             // new entity, also fill in created at
             $entity->setCreatedAt($changed_at);
         }

--- a/test/Listener/BlamableListenerTest.php
+++ b/test/Listener/BlamableListenerTest.php
@@ -22,15 +22,6 @@ class BlamableListenerTest extends \PHPUnit_Framework_TestCase
         $this->resolver = $this->createMock('Hostnet\Component\EntityBlamable\Resolver\BlamableResolverInterface');
         $this->provider = $this->createMock('Hostnet\Component\EntityBlamable\Provider\BlamableProviderInterface');
         $this->entity   = $this->createMock('Hostnet\Component\EntityBlamable\BlamableInterface');
-        $this->uow      = $this
-            ->getMockBuilder('Doctrine\ORM\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->em
-            ->expects($this->any())
-            ->method('getUnitOfWork')
-            ->willReturn($this->uow);
     }
 
     public function testOnEntityChangedNoInterface()
@@ -68,11 +59,6 @@ class BlamableListenerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('setUpdatedBy')
             ->with($by);
-
-        $this->uow
-            ->expects($this->once())
-            ->method('isScheduledForInsert')
-            ->willReturn(false);
 
         $this->resolver
             ->expects($this->once())
@@ -114,17 +100,12 @@ class BlamableListenerTest extends \PHPUnit_Framework_TestCase
             ->method('setUpdatedBy')
             ->with($by);
 
-        $this->uow
-            ->expects($this->once())
-            ->method('isScheduledForInsert')
-            ->willReturn(true);
-
         $this->resolver
             ->expects($this->once())
             ->method('getBlamableAnnotation')
             ->willReturn(new Blamable());
 
-        $event    = new EntityChangedEvent($this->em, $this->entity, new \stdClass(), []);
+        $event    = new EntityChangedEvent($this->em, $this->entity, null, []);
         $listener = new BlamableListener($this->resolver, $this->provider);
         $listener->entityChanged($event);
     }


### PR DESCRIPTION
Since new entities are send from the `PrePersist` event, the
unit of work no longer marks them as scheduled for insert. Checking
the original for `null` will provide you with the same information
in a much more elegant way and fixes the problem of having no `created_at`
filled in aswell.