### PR TITLE
removed hhvm from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ matrix:
         - php: 5.6
         - php: 7.0
         - php: 7.1
-        - php: hhvm
-    allow_failures:
-        - php: hhvm
 
 install:
     - composer install


### PR DESCRIPTION
see:

- https://symfony.com/blog/symfony-4-end-of-hhvm-support
- https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html