### PR TITLE
Attribute support, dropping PHP<8.3 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['8.3', '8.4']
     name: PHP ${{ matrix.php-versions }}
     steps:
       -   uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license":           "MIT",
     "minimum-stability": "stable",
     "require": {
-        "php":                              "^7.3|^8.0",
+        "php":                              "^8.3",
         "doctrine/orm":                     "^2.4.0",
         "hostnet/entity-tracker-component": "^1.2.0||^2.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "php":                              "^8.3",
         "doctrine/orm":                     "^2.4.0",
-        "hostnet/entity-tracker-component": "^1.2.0||^2.0.0"
+        "hostnet/entity-tracker-component": "^1.2.0||^2.0.0",
+        "symfony/cache":                    "^6.4|^7.4"
     },
     "require-dev": {
         "hostnet/phpcs-tool": "^9.1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php":                              "^8.3",
         "doctrine/orm":                     "^2.4.0",
-        "hostnet/entity-tracker-component": "^1.2.0||^2.0.0",
+        "hostnet/entity-tracker-component": "^2.3.0",
         "symfony/cache":                    "^6.4|^7.4"
     },
     "require-dev": {

--- a/src/Attributes/Blamable.php
+++ b/src/Attributes/Blamable.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @copyright 2026-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityBlamable\Attributes;
+
+use Hostnet\Component\EntityTracker\Attributes\Tracked;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Blamable extends Tracked
+{
+}

--- a/src/Blamable.php
+++ b/src/Blamable.php
@@ -11,6 +11,8 @@ use Hostnet\Component\EntityTracker\Annotation\Tracked;
 /**
  * @Annotation
  * @Target({"CLASS"})
+ *
+ * @deprecated Please use the attribute instead
  */
 class Blamable extends Tracked
 {

--- a/src/BlamableInterface.php
+++ b/src/BlamableInterface.php
@@ -8,6 +8,8 @@ namespace Hostnet\Component\EntityBlamable;
 
 /**
  * Implement on Entities to trigger the BlamableEntityListener
+ *
+ * @TODO: add (return)typehints on next BC break, when removing doctrine/annotations
  */
 interface BlamableInterface
 {

--- a/src/Listener/BlamableListener.php
+++ b/src/Listener/BlamableListener.php
@@ -6,11 +6,14 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityBlamable\Listener;
 
-use Hostnet\Component\EntityBlamable\Attributes\Blamable;
+use Doctrine\Persistence\ObjectManager;
 use Hostnet\Component\EntityBlamable\BlamableInterface;
 use Hostnet\Component\EntityBlamable\Provider\BlamableProviderInterface;
 use Hostnet\Component\EntityBlamable\Resolver\BlamableResolverInterface;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Listens to "Events::entityChanged"
@@ -20,31 +23,11 @@ use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
  */
 class BlamableListener
 {
-    /**
-     * @var BlamableResolverInterface
-     */
-    private $resolver;
-
-    /**
-     * @var BlamableProviderInterface
-     */
-    private $provider;
-
-    /**
-     * Caches the class names to prevent iterating over attribute and annotations again on the next entity.
-     */
-    private array $is_blamable_cache = [];
-
-    /**
-     * @param BlamableResolverInterface $resolver
-     * @param BlamableProviderInterface $provider
-     */
     public function __construct(
-        BlamableResolverInterface $resolver,
-        BlamableProviderInterface $provider
+        private BlamableResolverInterface $resolver,
+        private BlamableProviderInterface $provider,
+        private CacheItemPoolInterface $is_blamable_cache = new ArrayAdapter()
     ) {
-        $this->resolver = $resolver;
-        $this->provider = $provider;
     }
 
     /**
@@ -70,41 +53,35 @@ class BlamableListener
         }
     }
 
-    private function isBlamable($em, $entity): bool
+    private function isBlamable(ObjectManager $em, mixed $entity): bool
     {
-        $class = get_class($entity);
-        if (array_key_exists($class, $this->is_blamable_cache)) {
-            return $this->is_blamable_cache[$class];
+        $cache_key   = base64_encode('BLAMABLE-' . get_class($entity));
+        $cached_item = $this->is_blamable_cache->getItem($cache_key);
+
+        if ($cached_item->isHit()) {
+            return $cached_item->get();
         }
 
         if (!($entity instanceof BlamableInterface)) {
-            $this->is_blamable_cache[$class] = false;
-
-            return false;
+            return $this->save($cached_item, false);
         }
 
         if (null !== $this->resolver->getBlamableAnnotation($em, $entity)) {
-            $this->is_blamable_cache[$class] = true;
-
-            return true;
+            return $this->save($cached_item, true);
         }
 
-        if ($this->hasBlamableAttribute($entity)) {
-            $this->is_blamable_cache[$class] = true;
-
-            return true;
+        if (null !== $this->resolver->getBlamableAttribute($em, $entity)) {
+            return $this->save($cached_item, true);
         }
 
-        $this->is_blamable_cache[$class] = false;
-
-        return false;
+        return $this->save($cached_item, false);
     }
 
-    private function hasBlamableAttribute($entity): bool
+    private function save(CacheItemInterface $item, bool $value): bool
     {
-        $reflection = new \ReflectionClass($entity);
-        $attributes = $reflection->getAttributes(Blamable::class);
+        $item->set($value);
+        $this->is_blamable_cache->save($item);
 
-        return !empty($attributes);
+        return $value;
     }
 }

--- a/src/Listener/BlamableListener.php
+++ b/src/Listener/BlamableListener.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityBlamable\Listener;
 
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
 use Hostnet\Component\EntityBlamable\BlamableInterface;
 use Hostnet\Component\EntityBlamable\Provider\BlamableProviderInterface;
 use Hostnet\Component\EntityBlamable\Resolver\BlamableResolverInterface;
@@ -30,6 +31,11 @@ class BlamableListener
     private $provider;
 
     /**
+     * Caches the class names to prevent iterating over attribute and annotations again on the next entity.
+     */
+    private array $is_blamable_cache = [];
+
+    /**
      * @param BlamableResolverInterface $resolver
      * @param BlamableProviderInterface $provider
      */
@@ -44,12 +50,11 @@ class BlamableListener
     /**
      * @param EntityChangedEvent $event
      */
-    public function entityChanged(EntityChangedEvent $event)
+    public function entityChanged(EntityChangedEvent $event): void
     {
-        $entity     = $event->getCurrentEntity();
-        $annotation = $this->resolver->getBlamableAnnotation($event->getEntityManager(), $entity);
+        $entity = $event->getCurrentEntity();
 
-        if (null === $annotation || !$entity instanceof BlamableInterface) {
+        if (!$this->isBlamable($event->getEntityManager(), $entity)) {
             return;
         }
 
@@ -63,5 +68,43 @@ class BlamableListener
             // new entity, also fill in created at
             $entity->setCreatedAt($changed_at);
         }
+    }
+
+    private function isBlamable($em, $entity): bool
+    {
+        $class = get_class($entity);
+        if (array_key_exists($class, $this->is_blamable_cache)) {
+            return $this->is_blamable_cache[$class];
+        }
+
+        if (!($entity instanceof BlamableInterface)) {
+            $this->is_blamable_cache[$class] = false;
+
+            return false;
+        }
+
+        if (null !== $this->resolver->getBlamableAnnotation($em, $entity)) {
+            $this->is_blamable_cache[$class] = true;
+
+            return true;
+        }
+
+        if ($this->hasBlamableAttribute($entity)) {
+            $this->is_blamable_cache[$class] = true;
+
+            return true;
+        }
+
+        $this->is_blamable_cache[$class] = false;
+
+        return false;
+    }
+
+    private function hasBlamableAttribute($entity): bool
+    {
+        $reflection = new \ReflectionClass($entity);
+        $attributes = $reflection->getAttributes(Blamable::class);
+
+        return !empty($attributes);
     }
 }

--- a/src/Provider/BlamableProviderInterface.php
+++ b/src/Provider/BlamableProviderInterface.php
@@ -6,6 +6,9 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityBlamable\Provider;
 
+/**
+ * @TODO: add (return)typehints on next BC break, when removing doctrine/annotations
+ */
 interface BlamableProviderInterface
 {
     /**

--- a/src/Resolver/BlamableResolver.php
+++ b/src/Resolver/BlamableResolver.php
@@ -7,7 +7,8 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityBlamable\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Hostnet\Component\EntityBlamable\Blamable;
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
+use Hostnet\Component\EntityBlamable\Blamable as BlamabeAnnotation;
 use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
 
 class BlamableResolver implements BlamableResolverInterface
@@ -32,6 +33,11 @@ class BlamableResolver implements BlamableResolverInterface
      */
     public function getBlamableAnnotation(EntityManagerInterface $em, $entity)
     {
-        return $this->provider->getAnnotationFromEntity($em, $entity, Blamable::class);
+        return $this->provider->getAnnotationFromEntity($em, $entity, BlamabeAnnotation::class);
+    }
+
+    public function getBlamableAttribute(EntityManagerInterface $em, $entity): ?Blamable
+    {
+        return $this->provider->getAttributeFromEntity(Blamable::class, $em, $entity);
     }
 }

--- a/src/Resolver/BlamableResolver.php
+++ b/src/Resolver/BlamableResolver.php
@@ -7,15 +7,11 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityBlamable\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Hostnet\Component\EntityBlamable\Blamable;
 use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
 
 class BlamableResolver implements BlamableResolverInterface
 {
-    /**
-     * @var string
-     */
-    private $annotation = 'Hostnet\Component\EntityBlamable\Blamable';
-
     /**
      * @var EntityAnnotationMetadataProvider
      */
@@ -31,9 +27,11 @@ class BlamableResolver implements BlamableResolverInterface
 
     /**
      * @see \Hostnet\Component\EntityBlamable\Resolver\BlamableResolverInterface::getBlamableAnnotation()
+     *
+     * @deprecated Please use the attribute instead.
      */
     public function getBlamableAnnotation(EntityManagerInterface $em, $entity)
     {
-        return $this->provider->getAnnotationFromEntity($em, $entity, $this->annotation);
+        return $this->provider->getAnnotationFromEntity($em, $entity, Blamable::class);
     }
 }

--- a/src/Resolver/BlamableResolver.php
+++ b/src/Resolver/BlamableResolver.php
@@ -9,21 +9,12 @@ namespace Hostnet\Component\EntityBlamable\Resolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Hostnet\Component\EntityBlamable\Attributes\Blamable;
 use Hostnet\Component\EntityBlamable\Blamable as BlamabeAnnotation;
-use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
+use Hostnet\Component\EntityTracker\Provider\EntityMetadataProvider;
 
 class BlamableResolver implements BlamableResolverInterface
 {
-    /**
-     * @var EntityAnnotationMetadataProvider
-     */
-    private $provider;
-
-    /**
-     * @param EntityAnnotationMetadataProvider $provider
-     */
-    public function __construct(EntityAnnotationMetadataProvider $provider)
+    public function __construct(private EntityMetadataProvider $provider)
     {
-        $this->provider = $provider;
     }
 
     /**

--- a/src/Resolver/BlamableResolverInterface.php
+++ b/src/Resolver/BlamableResolverInterface.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityBlamable\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Hostnet\Component\EntityBlamable\Blamable;
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
 
 interface BlamableResolverInterface
 {
@@ -16,9 +16,10 @@ interface BlamableResolverInterface
      *
      * @param  EntityManagerInterface $em
      * @param  mixed                  $entity
-     * @return Blamable
      *
      * @deprecated Please use the attribute instead.
      */
     public function getBlamableAnnotation(EntityManagerInterface $em, $entity);
+
+    public function getBlamableAttribute(EntityManagerInterface $em, $entity): ?Blamable;
 }

--- a/src/Resolver/BlamableResolverInterface.php
+++ b/src/Resolver/BlamableResolverInterface.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityBlamable\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Hostnet\Component\EntityBlamable\Blamable;
 
 interface BlamableResolverInterface
 {
@@ -16,6 +17,8 @@ interface BlamableResolverInterface
      * @param  EntityManagerInterface $em
      * @param  mixed                  $entity
      * @return Blamable
+     *
+     * @deprecated Please use the attribute instead.
      */
     public function getBlamableAnnotation(EntityManagerInterface $em, $entity);
 }

--- a/test/Attributes/BlamableTest.php
+++ b/test/Attributes/BlamableTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright 2026-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityBlamable\Attributes;
+
+use Hostnet\Component\EntityTracker\Attributes\Tracked;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\EntityBlamable\Attributes\Blamable
+ */
+class BlamableTest extends TestCase
+{
+    public function test(): void
+    {
+        $blamable = new Blamable();
+
+        self::assertInstanceOf(Tracked::class, $blamable);
+    }
+}

--- a/test/Listener/BlamableListenerTest.php
+++ b/test/Listener/BlamableListenerTest.php
@@ -6,7 +6,8 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityBlamable\Listener;
 
-use Hostnet\Component\EntityBlamable\Blamable;
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
+use Hostnet\Component\EntityBlamable\Blamable as BlamableAnnotation;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
 use PHPUnit\Framework\TestCase;
 
@@ -68,7 +69,7 @@ class BlamableListenerTest extends TestCase
         $this->resolver
             ->expects($this->once())
             ->method('getBlamableAnnotation')
-            ->willReturn(new Blamable());
+            ->willReturn(new BlamableAnnotation());
 
         $event    = new EntityChangedEvent($this->em, $this->entity, new \stdClass(), []);
         $listener = new BlamableListener($this->resolver, $this->provider);
@@ -108,7 +109,7 @@ class BlamableListenerTest extends TestCase
         $this->resolver
             ->expects($this->once())
             ->method('getBlamableAnnotation')
-            ->willReturn(new Blamable());
+            ->willReturn(new BlamableAnnotation());
 
         $event    = new EntityChangedEvent($this->em, $this->entity, null, []);
         $listener = new BlamableListener($this->resolver, $this->provider);
@@ -134,6 +135,11 @@ class BlamableListenerTest extends TestCase
             ->expects($this->once())
             ->method('getBlamableAnnotation')
             ->willReturn(null);
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('getBlamableAttribute')
+            ->willReturn(new Blamable());
 
         $entity = new EntityWithAttribute();
         $event  = new EntityChangedEvent($this->em, $entity, null, []);
@@ -163,6 +169,11 @@ class BlamableListenerTest extends TestCase
         $this->resolver
             ->expects($this->once())
             ->method('getBlamableAnnotation')
+            ->willReturn(null);
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('getBlamableAttribute')
             ->willReturn(null);
 
         $entity = new EntityWithInterfaceOnly();

--- a/test/Listener/BlamableListenerTest.php
+++ b/test/Listener/BlamableListenerTest.php
@@ -114,4 +114,71 @@ class BlamableListenerTest extends TestCase
         $listener = new BlamableListener($this->resolver, $this->provider);
         $listener->entityChanged($event);
     }
+
+    public function testOnEntityChangedNewEntityWithAttribute(): void
+    {
+        $at = new \DateTime();
+        $by = 'henk';
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getChangedAt')
+            ->willReturn($at);
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getUpdatedBy')
+            ->willReturn($by);
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('getBlamableAnnotation')
+            ->willReturn(null);
+
+        $entity = new EntityWithAttribute();
+        $event  = new EntityChangedEvent($this->em, $entity, null, []);
+
+        $this->assertNull($entity->getCreatedAt());
+        $this->assertNull($entity->getUpdatedBy());
+        $this->assertNull($entity->getUpdatedAt());
+
+        $listener = new BlamableListener($this->resolver, $this->provider);
+        $listener->entityChanged($event);
+
+        $this->assertSame($at, $entity->getCreatedAt());
+        $this->assertSame($by, $entity->getUpdatedBy());
+        $this->assertSame($at, $entity->getUpdatedAt());
+    }
+
+    public function testOnEntityChangedNewEntityWithInterfaceOnly(): void
+    {
+        $this->provider
+            ->expects($this->never())
+            ->method('getChangedAt');
+
+        $this->provider
+            ->expects($this->never())
+            ->method('getUpdatedBy');
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('getBlamableAnnotation')
+            ->willReturn(null);
+
+        $entity = new EntityWithInterfaceOnly();
+        $event  = new EntityChangedEvent($this->em, $entity, null, []);
+
+        $this->assertNull($entity->getCreatedAt());
+        $this->assertNull($entity->getUpdatedBy());
+        $this->assertNull($entity->getUpdatedAt());
+
+        $listener = new BlamableListener($this->resolver, $this->provider);
+        $listener->entityChanged($event);
+
+        $this->assertNull($entity->getCreatedAt());
+        $this->assertNull($entity->getUpdatedBy());
+        $this->assertNull($entity->getUpdatedAt());
+
+        $listener->entityChanged($event); // cover the case where the blamable cache is already filled.
+    }
 }

--- a/test/Listener/EntityWithAttribute.php
+++ b/test/Listener/EntityWithAttribute.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright 2026-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityBlamable\Listener;
+
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
+use Hostnet\Component\EntityBlamable\BlamableInterface;
+
+#[Blamable]
+class EntityWithAttribute implements BlamableInterface
+{
+    private ?\DateTime $created_at = null;
+
+    private ?string $updated_by    = null;
+    private ?\DateTime $updated_at = null;
+
+    public function setUpdatedBy($by): void
+    {
+        $this->updated_by = $by;
+    }
+
+    public function getUpdatedBy(): ?string
+    {
+        return $this->updated_by;
+    }
+
+    public function setUpdatedAt(\DateTime $at): void
+    {
+        $this->updated_at = $at;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updated_at;
+    }
+
+    public function setCreatedAt(\DateTime $at): void
+    {
+        $this->created_at = $at;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->created_at;
+    }
+}

--- a/test/Listener/EntityWithInterfaceOnly.php
+++ b/test/Listener/EntityWithInterfaceOnly.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright 2026-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityBlamable\Listener;
+
+use Hostnet\Component\EntityBlamable\BlamableInterface;
+
+class EntityWithInterfaceOnly implements BlamableInterface
+{
+    private ?\DateTime $created_at = null;
+
+    private ?string $updated_by    = null;
+    private ?\DateTime $updated_at = null;
+
+    public function setUpdatedBy($by): void
+    {
+        $this->updated_by = $by;
+    }
+
+    public function getUpdatedBy(): ?string
+    {
+        return $this->updated_by;
+    }
+
+    public function setUpdatedAt(\DateTime $at): void
+    {
+        $this->updated_at = $at;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updated_at;
+    }
+
+    public function setCreatedAt(\DateTime $at): void
+    {
+        $this->created_at = $at;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->created_at;
+    }
+}

--- a/test/Resolver/BlamableResolverTest.php
+++ b/test/Resolver/BlamableResolverTest.php
@@ -6,6 +6,8 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityBlamable\Resolver;
 
+use Hostnet\Component\EntityBlamable\Attributes\Blamable;
+use Hostnet\Component\EntityBlamable\Blamable as BlamableAnnotation;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -39,8 +41,23 @@ class BlamableResolverTest extends TestCase
         $this->provider
             ->expects($this->once())
             ->method('getAnnotationFromEntity')
-            ->with($this->em, $entity, 'Hostnet\Component\EntityBlamable\Blamable');
+            ->with($this->em, $entity, BlamableAnnotation::class);
 
         $this->resolver->getBlamableAnnotation($this->em, $entity);
+    }
+
+    public function testGetRevisionAttribute(): void
+    {
+        $entity = new \stdClass();
+
+        $attribute = new Blamable();
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getAttributeFromEntity')
+            ->with(Blamable::class, $this->em, $entity)
+            ->willReturn($attribute);
+
+        self::assertSame($attribute, $this->resolver->getBlamableAttribute($this->em, $entity));
     }
 }


### PR DESCRIPTION
- add support for PHP attributes, deprecating the annotations
- drops PHP<8.3 support
- needs https://github.com/hostnet/entity-tracker-component/pull/45